### PR TITLE
Update mailchimp-transactional-node to v1.0.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.51
+* Added `maxBodyLength` and `maxContentLength` configurations to axios in order to prevent failures with `Request body larger than maxBodyLength limit` error message
+
 ### 1.0.50
 * Added a response parameter to /messages/send and /messages/send-template called 'queued_response' that details why an email was queued.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mailchimp/mailchimp_transactional",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "The official Node client library for the Mailchimp Transactional API",
   "license": "Apache 2.0",
   "main": "src/index.js",

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -42,9 +42,9 @@ var exports = function (apiKey = '') {
   this.formatList = ['json', 'xml', 'php', 'yaml'];
   this.contentTypes = ['application/json'];
   this.accepts = [
-    'application/json', 
-    'application/xml', 
-    'application/x-php', 
+    'application/json',
+    'application/xml',
+    'application/x-php',
     'application/x-yaml; charset=utf-8'
   ];
 
@@ -94,7 +94,10 @@ exports.prototype.post = function post(path, body = {}) {
   }
 
   return axios
-    .post(url, body)
+    .post(url, body, {
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity
+    })
     .then(function (response) {
       return response.data;
     })


### PR DESCRIPTION
* Added `maxBodyLength` and `maxContentLength` configurations to axios in order to prevent failures with `Request body larger than maxBodyLength limit` error message

Note: This repository is auto-generated, and does not accept pull requests.

To make changes or open issues for this SDK, use the [code generation repository](https://github.com/mailchimp/mailchimp-client-lib-codegen).
